### PR TITLE
Initial version based on official nginx image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM inclusivedesign/centos
+
+RUN yum install -y https://nginx.org/packages/rhel/7/noarch/RPMS/nginx-release-rhel-7-0.el7.ngx.noarch.rpm && \
+    yum install -y nginx && \
+    yum clean all && \
+    ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log
+
+EXPOSE 80 443
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 IDI Ops
+Copyright (c) 2016 OCAD University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Place this in a `Dockerfile` in the same directory as your content, run `docker 
 
 ## Exposing ports
 
-    $ docker run --name some-nginx -d -p 8080:80 my-content
+    $ docker run --name some-nginx -d -p 8080:80 inclusivedesign/nginx
 
 ## Complex configuration
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # docker-nginx
-Nginx Docker image
+
+Docker image based on CentOS 7.x and the latest Nginx stable version.
+
+# Usage
+
+## Simple static content
+
+You can point the Docker image at some directory with your static website:
+
+    $ docker run --name some-nginx -v /some/content:/usr/share/nginx/html:ro -d inclusivedesign/nginx
+
+Or generate a new image with your static website baked in:
+
+    FROM inclusivedesign/docker
+    COPY static-html-directory /usr/share/nginx/html
+
+Place this in a `Dockerfile` in the same directory as your content, run `docker build -t my-content .` then start your container using the `my-content` image:
+
+    $ docker run --name my-content -d my-content
+
+## Exposing ports
+
+    $ docker run --name some-nginx -d -p 8080:80 my-content
+
+## Complex configuration
+
+You can run more complex configurations by mounting the nginx.conf file directly into the container:
+
+    $ docker run --name some-nginx -v /path/to/nginx.conf:/etc/nginx/nginx.conf:ro -d inclusivedesign/nginx
+
+Be sure to include `daemon off;` in your custom configuration to ensure Nginx always runs in the foreground. That's necessary so Docker can properly track the process.


### PR DESCRIPTION
It works just like `nginx` to host simple static content, in that it's simple and doesn't offer any other features.

I've avoided using Ansible or anything more complicated because the logic seemed very simple, just like we want in a Kubernetes cluster (where load balancing, TLS termination, redirects, etc, happen in some external service).